### PR TITLE
Add provider and status APIs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,3 +13,4 @@ export { ITransaction } from "./src/v1/interfaces/data/ITransaction";
 export { ICard } from "./src/v1/interfaces/data/ICard";
 export { ICardBalance } from "./src/v1/interfaces/data/ICardBalance";
 export { ICardTransaction } from "./src/v1/interfaces/data/ICardTransaction";
+export { IProviderInfo } from "./src/v1/interfaces/auth/IProviderInfo";

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 export { AuthAPIClient } from "./src/v1/AuthAPIClient";
 export { DataAPIClient } from "./src/v1/DataAPIClient";
+export { StatusAPIClient } from "./src/v1/StatusAPIClient";
 export { Constants } from "./src/v1/Constants";
 export { IAccount } from "./src/v1/interfaces/data/IAccount";
 export { IBalance } from "./src/v1/interfaces/data/IBalance";
@@ -14,3 +15,4 @@ export { ICard } from "./src/v1/interfaces/data/ICard";
 export { ICardBalance } from "./src/v1/interfaces/data/ICardBalance";
 export { ICardTransaction } from "./src/v1/interfaces/data/ICardTransaction";
 export { IProviderInfo } from "./src/v1/interfaces/auth/IProviderInfo";
+export { IStatusInfo } from "./src/v1/interfaces/status/IStatusInfo";

--- a/src/v1/AuthAPIClient.ts
+++ b/src/v1/AuthAPIClient.ts
@@ -2,8 +2,8 @@ import { ApiError } from "./APIError";
 import { Constants } from "./Constants";
 import { IAuthResponse } from "./interfaces/auth/IAuthResponse";
 import { IOptions } from "./interfaces/auth/IOptions";
+import { IProviderInfo } from './interfaces/auth/IProviderInfo';
 import { ITokenResponse } from "./interfaces/auth/ITokenResponse";
-import * as moment from "moment";
 import * as request from "request-promise";
 
 /**
@@ -169,4 +169,27 @@ export class AuthAPIClient {
             throw new ApiError(error);
         }
     }
+
+    /**
+     * Gets info about available providers
+     * Docs: https://docs.truelayer.com/#list-of-supported-providers
+     *
+     * @param {string} [type] when provided, returns only providers of the given type
+    */
+   public static async getProviderInfos(
+       type?: "credentialssharing" | "oauth" | "oauth/openbanking",
+   ): Promise<IProviderInfo[]> {
+
+       const requestOptions: request.Options = {
+           uri: `${Constants.AUTH_URL}/api/providers/${type || ""}`,
+       }
+
+       try {
+           const response: string = await request.get(requestOptions);
+           const parsedResponse: IProviderInfo[] = JSON.parse(response);
+           return parsedResponse;
+       } catch (error) {
+           throw new ApiError(error);
+       }
+   }
 }

--- a/src/v1/Constants.ts
+++ b/src/v1/Constants.ts
@@ -6,5 +6,6 @@ export class Constants {
     // Constants
     public static readonly AUTH_URL: string = "https://auth.truelayer.com";
     public static readonly API_URL: string = "https://api.truelayer.com";
+    public static readonly STATUS_URL: string = "https://status-api.truelayer.com";
     public static readonly API_TIMEOUT: number = 60000;
 }

--- a/src/v1/StatusAPIClient.ts
+++ b/src/v1/StatusAPIClient.ts
@@ -53,6 +53,7 @@ export class StatusAPIClient {
 
         if (qs) {
             requestOptions.qs = qs;
+            requestOptions.useQuerystring = true;
         }
 
         return requestOptions;
@@ -74,8 +75,8 @@ export class StatusAPIClient {
         const qs = {
             from: moment(from).format(dateFormat),
             to: moment(to).format(dateFormat),
-            providers,
-            endpoints
+            providers: providers ? providers.join(",") : null,
+            endpoints: endpoints ? endpoints.join(",") : null,
         };
         return await StatusAPIClient.callAPI<IStatusInfo>(url, qs);
     }

--- a/src/v1/StatusAPIClient.ts
+++ b/src/v1/StatusAPIClient.ts
@@ -1,0 +1,82 @@
+import { ApiError } from "./APIError";
+import { Constants } from "./Constants";
+import { IResult } from "./interfaces/data/IResponse";
+import * as request from "request-promise";
+
+import { IStatusInfo } from "./interfaces/status/IStatusInfo";
+import moment = require("moment");
+
+/**
+ * Class responsible for calling to the Data endpoints
+ */
+export class StatusAPIClient {
+    /**
+     * Generic API calling function
+     *
+     * @template T
+     * @param {string} accessToken
+     * @param {string} path
+     * @param {object} [qs]
+     * @returns {Promise<IResult<T>>}
+     */
+    public static async callAPI<T>(
+        path: string,
+        qs?: object
+    ): Promise<IResult<T>> {
+        const requestOptions = StatusAPIClient.buildRequestOptions(path, qs);
+        try {
+            const response = await request.get(requestOptions);
+            const parsedResponse: IResult<T> = JSON.parse(response);
+            return parsedResponse;
+        } catch (error) {
+            throw new ApiError(error);
+        }
+    }
+
+    /**
+     * Build Request options
+     *
+     * @private
+     * @param {string} accessToken
+     * @param {string} path
+     * @param {object} [qs]
+     * @returns {request.Options}
+     */
+    public static buildRequestOptions(
+        path: string,
+        qs?: object
+    ): request.Options {
+        const requestOptions: request.Options = {
+            uri: path,
+            timeout: Constants.API_TIMEOUT
+        };
+
+        if (qs) {
+            requestOptions.qs = qs;
+        }
+
+        return requestOptions;
+    }
+
+    /**
+     * Call to /data/status API.
+     *
+     * @returns {Promise<IResult<IStatusInfo>>}
+     */
+    public static async getStatus(
+        from?: Date,
+        to?: Date,
+        providers?: string[],
+        endpoints?: string[]
+    ) {
+        const dateFormat = "YYYY-MM-DD HH:MM:SS";
+        const url = `${Constants.STATUS_URL}/api/v1/data/status`;
+        const qs = {
+            from: moment(from).format(dateFormat),
+            to: moment(to).format(dateFormat),
+            providers,
+            endpoints
+        };
+        return await StatusAPIClient.callAPI<IStatusInfo>(url, qs);
+    }
+}

--- a/src/v1/interfaces/auth/IJWT.ts
+++ b/src/v1/interfaces/auth/IJWT.ts
@@ -24,4 +24,4 @@ export interface IJWT {
  *
  * @type: Scope
  */
-export type Scope = "info" | "accounts" | "transactions" | "balance" | "offline_access";
+export type Scope = "info" | "accounts" | "transactions" | "balance" | "cards" | "offline_access";

--- a/src/v1/interfaces/auth/IProviderInfo.ts
+++ b/src/v1/interfaces/auth/IProviderInfo.ts
@@ -1,0 +1,21 @@
+import { IProvider } from '../data/ICard';
+import { Scope } from './IJWT';
+
+/**
+ * Description of a data provider.
+ * Docs: https://docs.truelayer.com/#list-of-supported-providers
+ *
+ * @interface IProviderInfo
+ */
+export interface IProviderInfo {
+    // NOTE: this could extend IProvider adding only the `scopes` field, but the
+    // naming is inconsistent (`logo_uri` / `logo_url`)
+    /** Unique TrueLayer provider ID **/
+    provider_id: string;
+    /** Human friendly provider name */
+    display_name: string;
+    /** URL to the providers logo as used by TrueLayer */
+    logo_url: string;
+    /** List of Permissions supported by the provider */
+    scopes: Scope[];
+}

--- a/src/v1/interfaces/status/IStatusInfo.ts
+++ b/src/v1/interfaces/status/IStatusInfo.ts
@@ -1,6 +1,6 @@
 export interface IStatusInfo {
     /** A string containing the provider id */
-    providers?: IProviderStatus[];
+    providers: IProviderStatus[];
     /** The start of a one-hour time bucket */
     timestamp: string;
 }

--- a/src/v1/interfaces/status/IStatusInfo.ts
+++ b/src/v1/interfaces/status/IStatusInfo.ts
@@ -1,0 +1,24 @@
+export interface IStatusInfo {
+    /** A string containing the provider id */
+    providers?: IProviderStatus[];
+    /** The start of a one-hour time bucket */
+    timestamp: string;
+}
+
+export interface IProviderStatus {
+    /** A string containing the provider id */
+    provider_id: string;
+    /** Array of availability data for requested endpoints  * @type {IEndpoint} */
+    endpoints: IEndpoint[];
+}
+
+export interface IEndpoint {
+    /** Partial URL of the endpoint */
+    endpoint: string;
+    /** The percentage of successful requests for a provider's endpoint represented as a float value between 0-100 */
+    availability: number;
+    /** The percentage of unsuccessful requests (that we know are on the provider side) for a provider's endpoint represented as a float value between 0-100 */
+    provider_error: number;
+    /** The percentage of unsuccessful requests (due to TrueLayer) for a provider's endpoint represented as a float value between 0-100 */
+    truelayer_error: number;
+}

--- a/test/integration/integration.spec.ts
+++ b/test/integration/integration.spec.ts
@@ -3,6 +3,7 @@ import { DataAPIClient } from "../../src/v1/DataAPIClient";
 import { test } from "ava";
 import * as moment from "moment";
 import * as TrueLayer from "./../../index";
+import { StatusAPIClient } from "../../src/v1/StatusAPIClient";
 
 // Get access token from environment variable
 const access_token: string = process.env.access_token;
@@ -258,3 +259,13 @@ if (DataAPIClient.validateToken(access_token)) {
 } else {
     test("No 'access_token' environment variable set. Integration test disabled.", (t) => t.pass());
 }
+
+test.serial("Get /data/status returns success", async (t) => {
+    t.plan(1);
+    const from = new Date(Date.parse("2019-01-07T10:00:00"));
+    const to = new Date(Date.parse("2019-01-08T13:00:00"));
+    const providers = ["hsbc", "oauth-monzo", "ob-barclays"];
+    const endpoints = ["accounts", "info"];
+    const response = await t.notThrows(StatusAPIClient.getStatus(from, to, providers, endpoints));
+    console.dir(response);
+});

--- a/test/integration/integration.spec.ts
+++ b/test/integration/integration.spec.ts
@@ -260,12 +260,23 @@ if (DataAPIClient.validateToken(access_token)) {
     test("No 'access_token' environment variable set. Integration test disabled.", (t) => t.pass());
 }
 
+const now = moment(new Date(Date.now())).startOf("hour");
+const from = now.clone().subtract(2, "hours").toDate();
+const to = now.clone().subtract(1, "hours").toDate();
+const providers = ["hsbc", "oauth-monzo", "ob-barclays"];
+const endpoints = ["accounts", "info"];
+
 test.serial("Get /data/status returns success", async (t) => {
     t.plan(1);
-    const from = new Date(Date.parse("2019-01-07T10:00:00"));
-    const to = new Date(Date.parse("2019-01-08T13:00:00"));
-    const providers = ["hsbc", "oauth-monzo", "ob-barclays"];
-    const endpoints = ["accounts", "info"];
-    const response = await t.notThrows(StatusAPIClient.getStatus(from, to, providers, endpoints));
-    console.dir(response);
+    await t.notThrows(StatusAPIClient.getStatus(from, to, providers, endpoints));
+});
+
+test.serial("Get /data/status actually returns something", async (t) => {
+    t.plan(1);
+    const statuses = (await StatusAPIClient.getStatus(from, to, providers, endpoints)).results;
+    const receivedProviders: string[] = [];
+    for (const status of statuses) {
+        status.providers.map((p) => receivedProviders.push(p.provider_id));
+    }
+    t.deepEqual(receivedProviders, providers);
 });

--- a/test/unit/auth.spec.ts
+++ b/test/unit/auth.spec.ts
@@ -75,3 +75,12 @@ test("Exchange code for token", async (t) => {
     t.deepEqual(actual.access_token, expected.access_token, "Access token not as expected");
     t.deepEqual(actual.refresh_token, expected.refresh_token, "Refresh token not as expected");
 });
+
+test("Get providers", async (t) => {
+    t.plan(2);
+    const stub = sinon.stub(request, "get").returns(JSON.stringify(fixtures.providersResponse))
+    const actual = await AuthAPIClient.getProviderInfos("oauth");
+    const expectedGetUri = "https://auth.truelayer.com/api/providers/oauth";
+    t.is(stub.getCall(0).args[0].uri, expectedGetUri);
+    t.deepEqual(actual, fixtures.providersResponse);
+});

--- a/test/unit/fixtures.ts
+++ b/test/unit/fixtures.ts
@@ -10,6 +10,7 @@ import { ICard } from "../../src/v1/interfaces/data/ICard";
 import { ICardBalance } from "../../src/v1/interfaces/data/ICardBalance";
 import { ICardTransaction } from "../../src/v1/interfaces/data/ICardTransaction";
 import { IProviderInfo } from '../../src/v1/interfaces/auth/IProviderInfo';
+import { IStatusInfo } from "../../src/v1/interfaces/status/IStatusInfo";
 
 export class Fixtures {
 
@@ -181,40 +182,40 @@ export class Fixtures {
         {
             results: [
                 {
-                  timestamp: "2017-01-14T00:00:00",
-                  description: "PAYPAL EBAY",
-                  transaction_type: "DEBIT",
-                  transaction_category: "PURCHASE",
-                  amount: -10.0,
-                  currency: "GBP",
-                  transaction_id: "cd0a7d0ec46686b2bed54af7bbf17464",
-                  meta: {
-                    provider_transaction_category: "DEB"
-                  }
+                    timestamp: "2017-01-14T00:00:00",
+                    description: "PAYPAL EBAY",
+                    transaction_type: "DEBIT",
+                    transaction_category: "PURCHASE",
+                    amount: -10.0,
+                    currency: "GBP",
+                    transaction_id: "cd0a7d0ec46686b2bed54af7bbf17464",
+                    meta: {
+                        provider_transaction_category: "DEB"
+                    }
                 },
                 {
-                  timestamp: "2017-01-18T00:00:00",
-                  description: "PAYPAL BETFRED",
-                  transaction_type: "DEBIT",
-                  transaction_category: "PURCHASE",
-                  amount: -2.0,
-                  currency: "GBP",
-                  transaction_id: "848f99795dc9793aaa189980eccbf161",
-                  meta: {
-                    provider_transaction_category: "DEB"
-                  }
+                    timestamp: "2017-01-18T00:00:00",
+                    description: "PAYPAL BETFRED",
+                    transaction_type: "DEBIT",
+                    transaction_category: "PURCHASE",
+                    amount: -2.0,
+                    currency: "GBP",
+                    transaction_id: "848f99795dc9793aaa189980eccbf161",
+                    meta: {
+                        provider_transaction_category: "DEB"
+                    }
                 },
                 {
-                  timestamp: "2017-01-30T00:00:00",
-                  description: "MT SecureTrade Lim",
-                  transaction_type: "DEBIT",
-                  transaction_category: "PURCHASE",
-                  amount: -20.5,
-                  currency: "GBP",
-                  transaction_id: "ae19ae9a38dbc41c5ad952e3add7c2f5",
-                  meta: {
-                    provider_transaction_category: "DEB"
-                  }
+                    timestamp: "2017-01-30T00:00:00",
+                    description: "MT SecureTrade Lim",
+                    transaction_type: "DEBIT",
+                    transaction_category: "PURCHASE",
+                    amount: -20.5,
+                    currency: "GBP",
+                    transaction_id: "ae19ae9a38dbc41c5ad952e3add7c2f5",
+                    meta: {
+                        provider_transaction_category: "DEB"
+                    }
                 },
                 {
                     timestamp: "2017-02 - 01T00: 00:00+00:00",
@@ -366,7 +367,7 @@ export class Fixtures {
                 }
             ]
         };
-    
+
     // Expected /Cards/{id}/Balance json response
     public readonly cardBalanceResponse: IResult<ICardBalance> =
         {
@@ -451,4 +452,84 @@ export class Fixtures {
                 scopes: ["offline_access", "transactions"],
             }
         ];
+
+    // Expected auth /data/status response
+    public readonly statusResponse: IResult<IStatusInfo> =
+        {
+            "results": [
+                {
+                    "timestamp": "2019-01-07 10:00:00.000",
+                    "providers": [
+                        {
+                            "provider_id": "oauth-monzo",
+                            "endpoints": [
+                                {
+                                    "endpoint": "accounts",
+                                    "availability": 97.24,
+                                    "provider_error": 0,
+                                    "truelayer_error": 2.76
+                                },
+                                {
+                                    "endpoint": "accounts/balance",
+                                    "availability": 100,
+                                    "provider_error": 0,
+                                    "truelayer_error": 0
+                                }
+                            ]
+                        },
+                        {
+                            "provider_id": "oauth-starling",
+                            "endpoints": [
+                                {
+                                    "endpoint": "accounts",
+                                    "availability": 100,
+                                    "provider_error": 0,
+                                    "truelayer_error": 0
+                                },
+                                {
+                                    "endpoint": "accounts/balance",
+                                    "availability": 100,
+                                    "provider_error": 0,
+                                    "truelayer_error": 0
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "timestamp": "2019-01-07 11:00:00.000",
+                    "providers": [
+                        {
+                            "provider_id": "oauth-monzo",
+                            "endpoints": [
+                                {
+                                    "endpoint": "accounts",
+                                    "availability": 100,
+                                    "provider_error": 0,
+                                    "truelayer_error": 0
+                                },
+                                {
+                                    "endpoint": "accounts/balance",
+                                    "availability": 92.86,
+                                    "provider_error": 7.14,
+                                    "truelayer_error": 0
+                                }
+                            ]
+                        },
+                        {
+                            "provider_id": "oauth-starling",
+                            "endpoints": [
+                                {
+                                    "endpoint": "accounts",
+                                    "availability": 96.43,
+                                    "provider_error": 0,
+                                    "truelayer_error": 3.57
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+
 }

--- a/test/unit/fixtures.ts
+++ b/test/unit/fixtures.ts
@@ -9,6 +9,7 @@ import { ITransaction } from "../../src/v1/interfaces/data/ITransaction";
 import { ICard } from "../../src/v1/interfaces/data/ICard";
 import { ICardBalance } from "../../src/v1/interfaces/data/ICardBalance";
 import { ICardTransaction } from "../../src/v1/interfaces/data/ICardTransaction";
+import { IProviderInfo } from '../../src/v1/interfaces/auth/IProviderInfo';
 
 export class Fixtures {
 
@@ -382,7 +383,7 @@ export class Fixtures {
                     update_timestamp: "2017-10-12T07:17:54.8144949Z"
                 }
             ]
-        }
+        };
 
     public readonly cardTransactionsResponse: IResult<ICardTransaction> =
         {
@@ -432,5 +433,22 @@ export class Fixtures {
                     }
                 }
             ]
-        }
+        };
+
+    // Expected auth /api/providers response
+    public readonly providersResponse: IProviderInfo[] =
+        [
+            {
+                provider_id: "test_provider",
+                display_name: "Test Provider",
+                logo_url: "https://auth.truelayer.com/img/banks/banks-icons/mock-icon.svg",
+                scopes: ["accounts", "balance"],
+            },
+            {
+                provider_id: "test_provider2",
+                display_name: "Test Provider Two",
+                logo_url: "https://auth.truelayer.com/img/banks/banks-icons/mock-icon.svg",
+                scopes: ["offline_access", "transactions"],
+            }
+        ];
 }

--- a/test/unit/status.spec.ts
+++ b/test/unit/status.spec.ts
@@ -1,0 +1,28 @@
+import { Fixtures } from "./fixtures";
+import { test } from "ava";
+import * as request from "request-promise";
+import * as sinon from "sinon";
+import { StatusAPIClient } from "../../src/v1/StatusAPIClient";
+
+// Instantiate to access fixtures
+const fixtures = new Fixtures();
+
+// Create sinon instance
+const mock = sinon.sandbox.create();
+
+test.afterEach((t) => {
+    // After each test restore stubbed methods
+    mock.restore();
+});
+
+test.serial("stubbed request body for /data/status endpoint is correctly parsed", async (t) => {
+    const expected = fixtures.statusResponse;
+    mock.stub(request, "get").returns(JSON.stringify(expected));
+    const from = new Date("2019-01-07T10:00:00");
+    const to = new Date("2019-01-08T13:00:00");
+    const providers = ["hsbc", "oauth-monzo", "ob-barclays"];
+    const endpoints = ["accounts", "info"];
+    const actual = await StatusAPIClient.getStatus(from, to, providers, endpoints);
+    t.plan(1);
+    t.deepEqual(actual, expected);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,10 @@
         /* Redirect output structure to the directory. */
         "sourceMap": false,
         /* Generates corresponding '.map' file. */
-        "strict": true
+        "strict": true,
         /* Enable all strict type-checking options. */
+        "lib": ["es2017"],
+        /* Include the good stuff. */
     },
     "exclude": [
         "examples",


### PR DESCRIPTION
Added `GET /api/providers` as a static method in the `AuthAPIClient`, since it doesn't require authenthication. Includes a simple unit test.  I tried to stick to your coding style, but feel free to correct me :)