### PR TITLE
Corrected getAuthUrl call in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ const scopes = ["info", "accounts", "balance", "transactions", "offline_access",
 
 // Construct url and redirect to the auth dialog
 app.get("/", (req, res) => {
-    const authURL = client.getAuthUrl(redirect_uri, scopes, "foobar");
+    const authURL = client.getAuthUrl({
+        redirectURI: redirect_uri,
+        scope: scopes,
+        nonce: "foobar"
+    });
     res.redirect(authURL);
 });
 
@@ -110,7 +114,12 @@ The flow of authorization follows the protocol of [OAuth 2.0](https://oauth.net/
 1. The first step in authentication is to redirect the user to the TrueLayer Authentication Server. 
 
     ```javascript
-    const authURL = client.getAuthUrl(env.REDIRECT_URI, scope, "nonce", "form_post");
+    const authURL = client.getAuthUrl({
+        redirectURI: env.REDIRECT_URI,
+        scope,
+        nonce: "nonce",
+        responseMode: "form_post"
+    });
     res.redirect(authURL);
     ```
 


### PR DESCRIPTION
Options for `getAuthUrl` are passed incorrectly in the README.md. They should be passed as attributes of an object rather than as individual arguments. This is clear from [`AuthAPIClient.ts`](https://github.com/TrueLayer/truelayer-client-javascript/blob/49217d424bae7f45be8fd1babe3a13127f528ec2/src/v1/AuthAPIClient.ts#L45)